### PR TITLE
[#4] Add flake8 max-line-length setting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
To match with black formatter, increase max-line-length from 79 to 88.